### PR TITLE
Restrict CourseFactory to USDC and WETH on BASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules/
 # Hardhat Ignition deployments (all chains)
 ignition/deployments/**
 !ignition/deployments/.gitkeep
+
+todo.md

--- a/contracts/CourseFactory.sol
+++ b/contracts/CourseFactory.sol
@@ -10,6 +10,12 @@ import "./Crowdfund.sol";
 
 contract CourseFactory {
     address[] public deployedCourses;
+    
+    // Supported tokens on BASE
+    address public constant USDC_BASE = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913; // USDC on BASE
+    address public constant WETH_BASE = 0x4200000000000000000000000000000000000006; // Wrapped ETH on BASE
+    
+    mapping(address => bool) public supportedTokens;
 
     event CourseCreated(
         address indexed courseAddress,
@@ -17,6 +23,12 @@ contract CourseFactory {
         uint256 fundingGoal,
         uint256 deadline
     );
+    
+    constructor() {
+        // Initialize supported tokens
+        supportedTokens[USDC_BASE] = true;
+        supportedTokens[WETH_BASE] = true;
+    }
 
     // Changed createCourse to accept investorNftAddress and milestone data
     function createCourse(
@@ -32,6 +44,7 @@ contract CourseFactory {
     ) external returns (address) {
         // Input validation
         require(token != address(0), "token addr zero");
+        require(supportedTokens[token], "Token not supported on BASE");
         require(goal > 0, "goal=0");
         require(duration > 0, "duration=0");
         require(investorNftAddress != address(0), "nft addr zero");

--- a/test/CourseFactory.test.ts
+++ b/test/CourseFactory.test.ts
@@ -7,20 +7,38 @@ describe("CourseFactory", function () {
   async function deployFactoryFixture() {
     const [owner, creator] = await hre.viem.getWalletClients();
     const courseFactory = await hre.viem.deployContract("CourseFactory");
-    const token = await hre.viem.deployContract("ERC20Mock", [
+
+    // Deploy unsupported token for testing failure case
+    const unsupportedToken = await hre.viem.deployContract("ERC20Mock", [
       "Mock Token",
       "MOCK",
     ]);
+
     const investorNFT = await hre.viem.deployContract("InvestorNFT", [
       "Investor NFT",
       "INFT",
       owner.account.address,
     ]);
-    return { courseFactory, owner, creator, token, investorNFT };
+
+    // BASE token addresses (constants from the contract)
+    const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+    const WETH_BASE = "0x4200000000000000000000000000000000000006";
+
+    return {
+      courseFactory,
+      owner,
+      creator,
+      unsupportedToken,
+      investorNFT,
+      USDC_BASE,
+      WETH_BASE,
+    };
   }
 
   it("Should allow a user to create a new course", async function () {
-    const { courseFactory, owner, token, investorNFT } = await loadFixture(deployFactoryFixture);
+    const { courseFactory, owner, USDC_BASE, investorNFT } = await loadFixture(
+      deployFactoryFixture
+    );
 
     const fundingGoal = 1000n;
     const duration = 30n * 24n * 60n * 60n; // 30 days in seconds
@@ -28,12 +46,15 @@ describe("CourseFactory", function () {
     const milestonePayouts = [fundingGoal];
 
     const txHash = await (courseFactory as any).write.createCourse([
-      token.address,
+      USDC_BASE, // Use supported token
       fundingGoal,
       duration,
       investorNFT.address,
       milestoneDescriptions,
       milestonePayouts,
+      owner.account.address, // platformAdmin
+      owner.account.address, // platformWallet
+      1000n, // platformShare (10%)
     ]);
 
     const publicClient = await hre.viem.getPublicClient();
@@ -51,16 +72,15 @@ describe("CourseFactory", function () {
     // Verify the deployed course is stored (index 0)
     // For a public dynamic array Solidity creates a getter: deployedCourses(uint256) -> address
     const firstCourse = await courseFactory.read.deployedCourses([0n]);
-    expect(getAddress(firstCourse)).to.equal(
-      getAddress(evtArgs.courseAddress)
-    );
+    expect(getAddress(firstCourse)).to.equal(getAddress(evtArgs.courseAddress));
     expect(firstCourse).to.not.equal(
       "0x0000000000000000000000000000000000000000"
     );
   });
 
   it("Should revert if funding goal is zero", async function () {
-    const { courseFactory, creator, token, investorNFT } = await loadFixture(deployFactoryFixture);
+    const { courseFactory, creator, WETH_BASE, investorNFT, owner } =
+      await loadFixture(deployFactoryFixture);
 
     const fundingGoal = 0n;
     const duration = 7n * 24n * 60n * 60n; // 7 days in seconds
@@ -69,18 +89,22 @@ describe("CourseFactory", function () {
 
     await expect(
       (courseFactory as any).write.createCourse([
-        token.address,
+        WETH_BASE, // Use supported token
         fundingGoal,
         duration,
         investorNFT.address,
         milestoneDescriptions,
-        milestonePayouts
+        milestonePayouts,
+        owner.account.address, // platformAdmin
+        owner.account.address, // platformWallet
+        1000n, // platformShare (10%)
       ])
     ).to.be.rejectedWith("goal=0");
   });
 
   it("Should revert if deadline is not in the future", async function () {
-    const { courseFactory, creator, token, investorNFT } = await loadFixture(deployFactoryFixture);
+    const { courseFactory, creator, USDC_BASE, investorNFT, owner } =
+      await loadFixture(deployFactoryFixture);
     const fundingGoal = 1000n;
     const zeroDuration = 0n; // Duration of 0 should be rejected
     const milestoneDescriptions = ["Complete project"];
@@ -89,13 +113,71 @@ describe("CourseFactory", function () {
     // This should fail because duration=0 is not allowed
     await expect(
       (courseFactory as any).write.createCourse([
-        token.address,
+        USDC_BASE, // Use supported token
         fundingGoal,
         zeroDuration,
         investorNFT.address,
         milestoneDescriptions,
-        milestonePayouts
+        milestonePayouts,
+        owner.account.address, // platformAdmin
+        owner.account.address, // platformWallet
+        1000n, // platformShare (10%)
       ])
     ).to.be.rejectedWith("duration=0");
+  });
+
+  it("Should revert if token is not supported on BASE", async function () {
+    const { courseFactory, unsupportedToken, investorNFT, owner } =
+      await loadFixture(deployFactoryFixture);
+
+    const fundingGoal = 1000n;
+    const duration = 7n * 24n * 60n * 60n; // 7 days in seconds
+    const milestoneDescriptions = ["Complete project"];
+    const milestonePayouts = [fundingGoal];
+
+    // This should fail because the token is not in the supported tokens list
+    await expect(
+      (courseFactory as any).write.createCourse([
+        unsupportedToken.address, // Use unsupported token
+        fundingGoal,
+        duration,
+        investorNFT.address,
+        milestoneDescriptions,
+        milestonePayouts,
+        owner.account.address, // platformAdmin
+        owner.account.address, // platformWallet
+        1000n, // platformShare (10%)
+      ])
+    ).to.be.rejectedWith("Token not supported on BASE");
+  });
+
+  it("Should allow creation with WETH token", async function () {
+    const { courseFactory, owner, WETH_BASE, investorNFT } = await loadFixture(
+      deployFactoryFixture
+    );
+
+    const fundingGoal = 1000n;
+    const duration = 30n * 24n * 60n * 60n; // 30 days in seconds
+    const milestoneDescriptions = ["Complete project"];
+    const milestonePayouts = [fundingGoal];
+
+    const txHash = await (courseFactory as any).write.createCourse([
+      WETH_BASE, // Use WETH (supported token)
+      fundingGoal,
+      duration,
+      investorNFT.address,
+      milestoneDescriptions,
+      milestonePayouts,
+      owner.account.address, // platformAdmin
+      owner.account.address, // platformWallet
+      1000n, // platformShare (10%)
+    ]);
+
+    const publicClient = await hre.viem.getPublicClient();
+    await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+    // Verify the course was created successfully
+    const events = await courseFactory.getEvents.CourseCreated();
+    expect(events.length).to.equal(2); // This is the second test that creates a course
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enforced token whitelisting on BASE: course creation now accepts only approved tokens.
  - Initial supported tokens include USDC and WETH on BASE.
  - Clear error returned when attempting to use an unsupported token.

- Tests
  - Added tests for unsupported token rejection and successful creation with supported tokens.
  - Expanded coverage for deployed course tracking.

- Chores
  - Updated repository settings to ignore a root-level notes file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->